### PR TITLE
fixed issue where second timer is started after wifi reconnects

### DIFF
--- a/src/mgos_watchdog.c
+++ b/src/mgos_watchdog.c
@@ -16,6 +16,7 @@
 static char mgos_watchdog_host[16];
 static struct ping_option mgos_watchdog_ping_option;
 static int mgos_watchdog_retrycount;
+static bool watchdog_timer_initialised = false;
 
 /**
  * @brief Callback for NET timer
@@ -127,6 +128,10 @@ void mgos_watchdog_init_net()
  */
 void mgos_watchdog_init_net_timer(int interval)
 {
+
+    // Avoid initialising watchdog timer twice
+    if (watchdog_timer_initialised) return;
+
     memset(mgos_watchdog_host, 0, sizeof(mgos_watchdog_host));
     
     if (mgos_sys_config_get_watchdog_net_host() == NULL) {
@@ -159,6 +164,7 @@ void mgos_watchdog_init_net_timer(int interval)
 
     LOG(LL_DEBUG, ("Starting net timer with interval: %d, host: %s", interval, mgos_watchdog_host));
     mgos_set_timer(interval, MGOS_TIMER_REPEAT, mgos_watchdog_net_timer_cb, NULL);
+    watchdog_timer_initialised = true;
 }
 
 /**


### PR DESCRIPTION
My suspicion is that the behaviour is unintentional, but the current implementation starts a new timer every time a network connection is established. Should the user briefly restart their WiFi, this would cause the initialisation of multiple timers.

A simple initialisation check has been added to ensure a second timer is not initialised.

(Copy of #1 with typo fixed)